### PR TITLE
Remove virtualenvwrapper

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -25,9 +25,6 @@ export ANDROID_HOME
 [ -f pyenv ] && eval "$(pyenv init -)"
 eval "$(ssh-agent)" > /dev/null
 
-# Python Virtualenv
-source $(which virtualenvwrapper.sh)
-
 # Google Cloud SDK
 source "/opt/gcloud/google-cloud-sdk/path.zsh.inc"
 source "/opt/gcloud/google-cloud-sdk/completion.zsh.inc"


### PR DESCRIPTION
### Overview

Other tools are used (e.g. `pipx` and `poetry`) to manage isolated environments. Virtualenvwrapper is not needed anymore.